### PR TITLE
Display articles associated with user collections

### DIFF
--- a/app/controllers/reading_collections_controller.rb
+++ b/app/controllers/reading_collections_controller.rb
@@ -1,6 +1,7 @@
 class ReadingCollectionsController < ApplicationController
   def show
-    @collection = ReadingCollection.find_by(slug: params[:slug])
+    @collection = ReadingCollection.find_by(slug: params[:slug]).to_json
+    @articles = ReadingCollection.find_by(slug: params[:slug]).articles.to_json
   end
 
   def new; end

--- a/app/javascript/packs/collectionArticles.jsx
+++ b/app/javascript/packs/collectionArticles.jsx
@@ -1,0 +1,25 @@
+import { h, render } from 'preact';
+import { getUserDataAndCsrfToken } from '../chat/util';
+import { CollectionArticles } from '../readingList/collectionArticles';
+
+function loadElement() {
+  getUserDataAndCsrfToken().then(() => {
+    const root = document.getElementById('collection-articles');
+    if (root) {
+      render(
+        <CollectionArticles
+          articles={root.dataset.articles}
+          collection={root.dataset.collection}
+        />,
+        root,
+        root.firstElementChild,
+      );
+    }
+  });
+}
+
+window.InstantClick.on('change', () => {
+  loadElement();
+});
+
+loadElement();

--- a/app/javascript/readingList/__tests__/__snapshots__/collectionForm.test.jsx.snap
+++ b/app/javascript/readingList/__tests__/__snapshots__/collectionForm.test.jsx.snap
@@ -1,51 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<CollectionForm /> renders properly 1`] = `
-<div
-  class="articleformcontainer"
+<section
+  class="articleform"
 >
-  <section
-    class="articleform"
+  <form
+    class="articleform__form"
   >
-    <form
-      class="articleform__form"
+    <h1>
+      Add your new collection
+    </h1>
+    <input
+      class="articleform__title"
+      name="title"
+      onChange={[Function]}
+      placeholder="Collection Name..."
+      required={true}
+      type="text"
+    />
+    <div
+      class="articleform__tagswrapper"
     >
-      <h1>
-        Add your new collection
-      </h1>
       <input
-        class="articleform__title"
-        name="title"
-        onChange={[Function]}
-        placeholder="Title..."
-        required={true}
+        autoComplete="off"
+        class="articleform__tags"
+        id="tag-input"
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        placeholder="4 tags max, comma separated, no spaces or special characters"
+        ref={[Function]}
         type="text"
+        value=""
       />
-      <div
-        class="articleform__tagswrapper"
-      >
-        <input
-          autoComplete="off"
-          class="articleform__tags"
-          id="tag-input"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onInput={[Function]}
-          onKeyDown={[Function]}
-          placeholder="4 tags max, comma separated, no spaces or special characters"
-          ref={[Function]}
-          type="text"
-          value=""
-        />
-      </div>
-      <a
-        class="articleform__buttons--publish collection-btn"
-        href="readinglist"
-        type="button"
-      >
-        CREATE COLLECTION
-      </a>
-    </form>
-  </section>
-</div>
+    </div>
+    <button
+      class="articleform__buttons--publish button collection-btn"
+      onClick={[Function]}
+      type="button"
+    >
+      CREATE COLLECTION
+    </button>
+  </form>
+</section>
 `;

--- a/app/javascript/readingList/__tests__/__snapshots__/collectionList.test.jsx.snap
+++ b/app/javascript/readingList/__tests__/__snapshots__/collectionList.test.jsx.snap
@@ -6,9 +6,15 @@ exports[`<ContentList /> renders properly 1`] = `
   id="reading-collection"
 >
   <div
-    class="results-header"
+    class="results-header collection-header"
   >
     Collections (2)
+    <a
+      class="new-collection"
+      href="/readingcollections/new"
+    >
+      +
+    </a>
   </div>
   <section
     class="collection item-wrapper"
@@ -16,11 +22,12 @@ exports[`<ContentList /> renders properly 1`] = `
     <div
       class="item"
     >
-      <p
+      <a
         class="item-title"
+        href="/readingcollections/undefined"
       >
         first_test_post
-      </p>
+      </a>
     </div>
   </section>
   <section
@@ -29,11 +36,12 @@ exports[`<ContentList /> renders properly 1`] = `
     <div
       class="item"
     >
-      <p
+      <a
         class="item-title"
+        href="/readingcollections/undefined"
       >
         second_test_post
-      </p>
+      </a>
     </div>
   </section>
 </section>

--- a/app/javascript/readingList/__tests__/__snapshots__/readingList.test.jsx.snap
+++ b/app/javascript/readingList/__tests__/__snapshots__/readingList.test.jsx.snap
@@ -78,9 +78,15 @@ exports[`<ReadingList /> renders properly 1`] = `
       id="reading-collection"
     >
       <div
-        class="results-header"
+        class="results-header collection-header"
       >
         Collections (2)
+        <a
+          class="new-collection"
+          href="/readingcollections/new"
+        >
+          +
+        </a>
       </div>
       <section
         class="collection item-wrapper"
@@ -88,11 +94,12 @@ exports[`<ReadingList /> renders properly 1`] = `
         <div
           class="item"
         >
-          <p
+          <a
             class="item-title"
+            href="/readingcollections/undefined"
           >
             first_test_post
-          </p>
+          </a>
         </div>
       </section>
       <section
@@ -101,11 +108,12 @@ exports[`<ReadingList /> renders properly 1`] = `
         <div
           class="item"
         >
-          <p
+          <a
             class="item-title"
+            href="/readingcollections/undefined"
           >
             second_test_post
-          </p>
+          </a>
         </div>
       </section>
     </section>

--- a/app/javascript/readingList/__tests__/collectionArticles.test.jsx
+++ b/app/javascript/readingList/__tests__/collectionArticles.test.jsx
@@ -1,0 +1,10 @@
+import { h } from 'preact';
+import render from 'preact-render-to-json';
+import { CollectionArticles } from '../collectionArticles';
+
+describe('<CollectionForm />', () => {
+  it.skip('renders properly', () => {
+    const tree = render(<CollectionArticles />);
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/app/javascript/readingList/collectionArticles.jsx
+++ b/app/javascript/readingList/collectionArticles.jsx
@@ -2,15 +2,26 @@ import { h } from 'preact';
 import PropTypes from 'prop-types';
 import { Article } from './components/Article';
 
-export const CollectionArticles = collection => {
-  const articles = JSON.parse(collection.articles);
-  const articleList = articles.map(article => {
+export const CollectionArticles = ({ collection, articles }) => {
+  const collectionParse = JSON.parse(collection);
+  const articlesParse = JSON.parse(articles);
+  const articleList = articlesParse.map(article => {
     return <Article {...article} />;
   });
 
-  return <section className="collection item-wrapper">{articleList}</section>;
+  return (
+    <div className="items-container">
+      <section className="collection-cont results results--loaded">
+        <div className="results-header collection-header">
+          {`${collectionParse.name}`}
+        </div>
+        {articleList}
+      </section>
+    </div>
+  );
 };
 
 CollectionArticles.propTypes = {
   collection: PropTypes.string.isRequired,
+  articles: PropTypes.string.isRequired,
 };

--- a/app/javascript/readingList/collectionArticles.jsx
+++ b/app/javascript/readingList/collectionArticles.jsx
@@ -1,0 +1,16 @@
+import { h } from 'preact';
+import PropTypes from 'prop-types';
+import { Article } from './components/Article';
+
+export const CollectionArticles = collection => {
+  const articles = JSON.parse(collection.articles);
+  const articleList = articles.map(article => {
+    return <Article {...article} />;
+  });
+
+  return <section className="collection item-wrapper">{articleList}</section>;
+};
+
+CollectionArticles.propTypes = {
+  collection: PropTypes.string.isRequired,
+};

--- a/app/javascript/readingList/collectionList.jsx
+++ b/app/javascript/readingList/collectionList.jsx
@@ -2,8 +2,6 @@ import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
 import { Collection } from './components/Collection';
 
-// const root = document.getElementById('collection-list');
-
 export class CollectionList extends Component {
   constructor({ collections }) {
     super({ collections });
@@ -13,22 +11,16 @@ export class CollectionList extends Component {
     };
   }
 
-  componentDidMount() {
-    const { collections } = this.state;
-    if (!collections.length) {
-      this.setState({
-        collections: [
-          { id: 1, name: 'first_test_post' },
-          { id: 2, name: 'second_test_post' },
-        ],
-      });
-    }
-  }
-
   render() {
     const { collections } = this.state;
     const collectionsToRender = collections.map(collection => {
-      return <Collection key={collection.id} name={collection.name} />;
+      return (
+        <Collection
+          key={collection.id}
+          name={collection.name}
+          slug={collection.slug}
+        />
+      );
     });
 
     return (

--- a/app/javascript/readingList/components/Article.jsx
+++ b/app/javascript/readingList/components/Article.jsx
@@ -1,0 +1,58 @@
+/* eslint-disable camelcase */
+import { h } from 'preact';
+import PropTypes from 'prop-types';
+
+export const Article = ({
+  title,
+  path,
+  reading_time,
+  cached_tag_list,
+  created_at,
+}) => {
+  const tags = cached_tag_list.split(',');
+  const tagDisp = tags.map(tagRaw => {
+    const tag = tagRaw.trim();
+    return (
+      <a href={`/t/${tag}`}>
+        <span className="tag">{` #${tag}`}</span>
+      </a>
+    );
+  });
+  const createDate = new Date(created_at);
+  const createDay = createDate.getDate();
+  const createMonth = createDate.getMonth();
+  const monthNames = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+
+  return (
+    <section className="coll-article">
+      <a className="new-collection" href={`${path}`}>
+        {`${title}`}
+      </a>
+      <p>{`Reading Time: ${reading_time} min`}</p>
+      <p>{`${monthNames[createMonth]} ${createDay}`}</p>
+      <div className="featured-tags tags">{tagDisp}</div>
+      {/* <a href={`${story.cached_user.username}`} className="small-pic-link-wrapper" /> */}
+    </section>
+  );
+};
+
+Article.propTypes = {
+  title: PropTypes.string.isRequired,
+  path: PropTypes.string.isRequired,
+  reading_time: PropTypes.string.isRequired,
+  cached_tag_list: PropTypes.string.isRequired,
+  created_at: PropTypes.string.isRequired,
+};

--- a/app/javascript/readingList/components/Article.jsx
+++ b/app/javascript/readingList/components/Article.jsx
@@ -37,14 +37,15 @@ export const Article = ({
   ];
 
   return (
-    <section className="coll-article">
-      <a className="new-collection" href={`${path}`}>
-        {`${title}`}
-      </a>
-      <p>{`Reading Time: ${reading_time} min`}</p>
-      <p>{`${monthNames[createMonth]} ${createDay}`}</p>
-      <div className="featured-tags tags">{tagDisp}</div>
-      {/* <a href={`${story.cached_user.username}`} className="small-pic-link-wrapper" /> */}
+    <section className="collection item-wrapper">
+      <div className="item">
+        <a className="new-collection" href={`${path}`}>
+          {`${title}`}
+        </a>
+        <p>{`Reading Time: ${reading_time} min`}</p>
+        <p>{`${monthNames[createMonth]} ${createDay}`}</p>
+        <div className="featured-tags tags">{tagDisp}</div>
+      </div>
     </section>
   );
 };

--- a/app/javascript/readingList/components/Collection.jsx
+++ b/app/javascript/readingList/components/Collection.jsx
@@ -1,11 +1,13 @@
 import { h } from 'preact';
 import PropTypes from 'prop-types';
 
-export const Collection = ({ name }) => {
+export const Collection = ({ name, slug }) => {
   return (
     <section className="collection item-wrapper">
       <div className="item">
-        <p className="item-title">{`${name}`}</p>
+        <a href={`/readingcollections/${slug}`} className="item-title">
+          {`${name}`}
+        </a>
       </div>
     </section>
   );
@@ -13,4 +15,5 @@ export const Collection = ({ name }) => {
 
 Collection.propTypes = {
   name: PropTypes.string.isRequired,
+  slug: PropTypes.string.isRequired,
 };

--- a/app/views/reading_collections/show.html.erb
+++ b/app/views/reading_collections/show.html.erb
@@ -1,6 +1,8 @@
-<%= @collection.name %>
-<% @collection.articles.each do |article| %>
-  <div class="article">
-    <%= article.title %>
-  </div>
-<% end %>
+<% title "All collections" %>
+
+<div class="home">
+        <div class="articleformcontainer" id="collection-articles" data-collection="<%= @collection %>" data-articles="<%= @articles %>">
+        </div>
+</div>
+
+<%= javascript_pack_tag "collectionArticles", defer: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -215,6 +215,7 @@ Rails.application.routes.draw do
   resources :podcasts, only: %i[new create]
   resolve("ProMembership") { [:pro_membership] } # see https://guides.rubyonrails.org/routing.html#using-resolve
 
+  get "/readingcollections/new" => "reading_collections#new"
   get "/readingcollections/:slug" => "reading_collections#show"
 
   get "/search/tags" => "search#tags"
@@ -367,8 +368,6 @@ Rails.application.routes.draw do
   get "/podcasts", to: redirect("pod")
   get "/readinglist" => "reading_list_items#index"
   get "/readinglist/:view" => "reading_list_items#index", :constraints => { view: /archive/ }
-
-  get "/readingcollections/new", to: "reading_collections#new"
 
   get "/feed" => "articles#feed", :as => "feed", :defaults => { format: "rss" }
   get "/feed/tag/:tag" => "articles#feed",


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR adds the ability for users to click on their collections to view a list of all the articles within that collection. On that article view a user can click through to the articles, or to any of the respective tags associated with that article. 

## Related Tickets & Documents
#21 

## Added tests?

- [X] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed
- [X] no to be added

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
